### PR TITLE
CI: Test on newer node versions and use modern yarn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,17 @@ node_js:
   - 10
   - 8
 
-before_install: yarn global add greenkeeper-lockfile@1
+before_install:
+  - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
+  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+  - sudo apt-get update -qq
+  - sudo apt-get install -y -qq yarn
+  - yarn global add greenkeeper-lockfile@1
 install: yarn install
 cache:
   yarn: true
   directories:
     - node_modules
-
 before_script:
   - greenkeeper-lockfile-update
   - yarn clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ node_js:
   - 8
 
 before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.12.3
+  - export PATH=$HOME/.yarn/bin:$PATH
   - yarn global add greenkeeper-lockfile@1
 install: yarn install
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ addons:
       - libnss3
 language: node_js
 node_js:
+  - 11
+  - 10
   - 8
 
 before_install: yarn global add greenkeeper-lockfile@1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,3 @@
-dist: trusty
-addons:
-  apt:
-    packages:
-      # Needed for Chrome on Trusty
-      - libnss3
 language: node_js
 node_js:
   - 11
@@ -11,10 +5,6 @@ node_js:
   - 8
 
 before_install:
-  - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
-  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-  - sudo apt-get update -qq
-  - sudo apt-get install -y -qq yarn
   - yarn global add greenkeeper-lockfile@1
 install: yarn install
 cache:


### PR DESCRIPTION
Run the tests on Travis for node 8, 10 and 11. Use the latest yarn so that lockfile PRs from greenkeeper won't keep trying to remove the integrity hashes.