### PR TITLE
fix waitForSelector resolve to type

### DIFF
--- a/__tests__/puppeteer_test.re
+++ b/__tests__/puppeteer_test.re
@@ -348,7 +348,9 @@ describe("Page", () => {
   testPromise("waitForSelector()", () =>
     Js.Promise.(
       (page^)->Page.waitForSelector("body", ())
-      |> then_(() => pass |> resolve)
+      |> then_(elementHandle =>
+           elementHandle |> expect |> ExpectJs.toBeTruthy |> resolve
+         )
     )
   );
 

--- a/examples/search.re
+++ b/examples/search.re
@@ -13,27 +13,29 @@ let search = () =>
             let allResultsSelector = ".devsite-suggest-all-results";
             let options =
               Navigation.makeOptions(~timeout=20000., ~waitUntil=`load, ());
-            page
-            ->Page.goto("https://developers.google.com/web/", ~options, ())
+            page->Page.goto(
+              "https://developers.google.com/web/",
+              ~options,
+              (),
+            )
             /* Type into the search box */
             |> then_(_ =>
                  page->Page.type_("#searchbox input", "puppeteer", ())
                )
             /* Wait for suggestion overlay to show up then click "all results". */
             |> then_(_ => page->Page.waitForSelector(allResultsSelector, ()))
-            |> then_(() => page->Page.click(allResultsSelector, ()))
+            |> then_(elmt => Js.Null.getExn(elmt)->ElementHandle.click())
             /* Wait for load of results page. */
             |> then_(() => {
                  let resultsSelector = ".gsc-results .gsc-thumbnail-inside a.gs-title";
                  page->Page.waitForSelector(resultsSelector, ());
                })
             /* Get the title of the first result. */
-            |> then_(() =>
-                 page
-                 ->Page.selectOneEval(
-                     "a.gs-title",
-                     Webapi.Dom.Element.textContent,
-                   )
+            |> then_(_ =>
+                 page->Page.selectOneEval(
+                   "a.gs-title",
+                   Webapi.Dom.Element.textContent,
+                 )
                )
             /* Log the result title. */
             |> then_(text =>

--- a/src/FrameBase.re
+++ b/src/FrameBase.re
@@ -71,7 +71,7 @@ let waitForNavigation = (page, ~options) =>
 
 [@bs.send]
 external waitForSelector:
-  (t, string, ~options: selectorOptions=?, unit) => Js.Promise.t(unit) =
+  (t, string, ~options: selectorOptions=?, unit) => Js.Promise.t(Js.Null.t(ElementHandle.t('a))) =
   "";
 
 [@bs.send]


### PR DESCRIPTION
It resolved to a possible Element handle just like `$`.

BREAKING CHANGE: the return type of the waitForSelector has changed.