### PR TITLE
Changed jsonValue return type to be Js.Json.t

### DIFF
--- a/__tests__/fixtures/testPage.html
+++ b/__tests__/fixtures/testPage.html
@@ -7,7 +7,7 @@
     </style>
   </head>
   <body>
-    <input type="text" id="input" />
+    <input type="text" id="input" class="class1 class2" />
     <iframe id="iframe" src="about:blank"></iframe>
     <script>
     function foo() {function bar() { } console.log(1); } foo(); </script>

--- a/src/JSHandle.re
+++ b/src/JSHandle.re
@@ -19,7 +19,7 @@ module Impl = (T: {type t('a);}) => {
     "getProperty";
 
   [@bs.send]
-  external jsonValue: T.t('a) => Js.Promise.t(Js.t({..})) = "jsonValue";
+  external jsonValue: T.t('a) => Js.Promise.t(Js.Json.t) = "jsonValue";
 };
 
 type t('a) = Types.jsHandle('a);


### PR DESCRIPTION
Puppeteer docs describe jsonValue()  as returning a JSON representation
of the object. In some cases the object is simply a string (such as
getting a property as the test case does), for these cases, using
a Js.Json.t return type is more robust.